### PR TITLE
Add Bark and Coqui TTS options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+output.wav

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Open the colab notebook from [here](https://github.com/SamurAIGPT/AI-Influencer/
 
 ### Technologies used
 
-Text-to-speech via [Bark](https://github.com/suno-ai/bark) or [Coqui TTS](https://github.com/coqui-ai/TTS)
+gTTS for simple text-to-speech
+
+Bark or [Coqui TTS](https://github.com/coqui-ai/TTS) for high-quality voice synthesis
 
 Sad-Talker for lip-sync
 
@@ -33,9 +35,10 @@ Stable diffusion for image generation
 The repository ships with a small utility [`voice_synthesis.py`](./voice_synthesis.py)
 that can generate speech either with [Bark](https://github.com/suno-ai/bark) or
 [Coqui TTS](https://github.com/coqui-ai/TTS). Select the engine with the
-`TTS_ENGINE` environment variable. The default is `bark`.
+`TTS_ENGINE` environment variable or pass `--engine` when calling the script.
+The default engine is `bark`.
 
-Example:
+Set the environment variable:
 
 ```bash
 export TTS_ENGINE=coqui  # or "bark"
@@ -44,6 +47,9 @@ export TTS_ENGINE=coqui  # or "bark"
 ```python
 from voice_synthesis import generate_voice
 audio_file = generate_voice("Hello world!", voice_profile=None)
+
+# Or from the command line
+python voice_synthesis.py "Hello world!" --engine coqui
 ```
 
 Specify a voice profile when using Bark (e.g. `"en_speaker_6"`) or a model name

--- a/README.md
+++ b/README.md
@@ -20,13 +20,35 @@ Open the colab notebook from [here](https://github.com/SamurAIGPT/AI-Influencer/
 
 ### Technologies used
 
-gTTS for text to speech
+Text-to-speech via [Bark](https://github.com/suno-ai/bark) or [Coqui TTS](https://github.com/coqui-ai/TTS)
 
 Sad-Talker for lip-sync
 
 OpenAI for generating prompt for AI image generation
 
 Stable diffusion for image generation
+
+### Voice Synthesis
+
+The repository ships with a small utility [`voice_synthesis.py`](./voice_synthesis.py)
+that can generate speech either with [Bark](https://github.com/suno-ai/bark) or
+[Coqui TTS](https://github.com/coqui-ai/TTS). Select the engine with the
+`TTS_ENGINE` environment variable. The default is `bark`.
+
+Example:
+
+```bash
+export TTS_ENGINE=coqui  # or "bark"
+```
+
+```python
+from voice_synthesis import generate_voice
+audio_file = generate_voice("Hello world!", voice_profile=None)
+```
+
+Specify a voice profile when using Bark (e.g. `"en_speaker_6"`) or a model name
+when using Coqui TTS (e.g. `"tts_models/en/ljspeech/tacotron2-DDC"`). The
+function returns the path to a generated `wav` file.
 
 ## 💁 Contribution
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/suno-ai/bark.git
+git+https://github.com/coqui-ai/TTS.git

--- a/voice_synthesis.py
+++ b/voice_synthesis.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 
 def generate_voice(text: str, voice_profile: str = None, engine: str = None) -> str:
@@ -24,13 +25,14 @@ def generate_voice(text: str, voice_profile: str = None, engine: str = None) -> 
 
     engine = (engine or os.getenv("TTS_ENGINE", "bark")).lower()
 
-    output_path = Path("output.wav")
+    temp_file = NamedTemporaryFile(delete=False, suffix=".wav")
+    output_path = Path(temp_file.name)
 
     if engine == "coqui":
         from TTS.api import TTS
 
         model_name = voice_profile or "tts_models/en/ljspeech/tacotron2-DDC"
-        tts = TTS(model_name)
+        tts = TTS(model_name=model_name)
         tts.tts_to_file(text, file_path=str(output_path))
     else:
         from bark import SAMPLE_RATE, generate_audio
@@ -41,3 +43,16 @@ def generate_voice(text: str, voice_profile: str = None, engine: str = None) -> 
         sf.write(output_path, np.array(audio_array), SAMPLE_RATE)
 
     return str(output_path)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate speech using Bark or Coqui")
+    parser.add_argument("text", help="Text to convert to speech")
+    parser.add_argument("--engine", default=None, help="Choose 'bark' or 'coqui'. Defaults to env TTS_ENGINE")
+    parser.add_argument("--voice-profile", default=None, help="Voice profile or model name")
+    args = parser.parse_args()
+
+    path = generate_voice(args.text, voice_profile=args.voice_profile, engine=args.engine)
+    print(path)

--- a/voice_synthesis.py
+++ b/voice_synthesis.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+
+
+def generate_voice(text: str, voice_profile: str = None, engine: str = None) -> str:
+    """Generate speech audio for the given text using the selected TTS engine.
+
+    Parameters
+    ----------
+    text : str
+        The text to synthesize.
+    voice_profile : str, optional
+        Name or path of a voice profile/model. Interpretation depends on the
+        chosen engine.
+    engine : str, optional
+        Either ``"bark"`` or ``"coqui"``. When ``None``, the value of the
+        ``TTS_ENGINE`` environment variable is used, defaulting to ``"bark"``.
+
+    Returns
+    -------
+    str
+        Path to the generated ``.wav`` file.
+    """
+
+    engine = (engine or os.getenv("TTS_ENGINE", "bark")).lower()
+
+    output_path = Path("output.wav")
+
+    if engine == "coqui":
+        from TTS.api import TTS
+
+        model_name = voice_profile or "tts_models/en/ljspeech/tacotron2-DDC"
+        tts = TTS(model_name)
+        tts.tts_to_file(text, file_path=str(output_path))
+    else:
+        from bark import SAMPLE_RATE, generate_audio
+        import numpy as np
+        import soundfile as sf
+
+        audio_array = generate_audio(text, history_prompt=voice_profile)
+        sf.write(output_path, np.array(audio_array), SAMPLE_RATE)
+
+    return str(output_path)


### PR DESCRIPTION
## Summary
- add requirements for Bark and Coqui TTS
- implement `voice_synthesis.py` utility
- document how to use Bark or Coqui for voice synthesis

## Testing
- `python -m py_compile voice_synthesis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840fb378c30832b9811a06bf8994e1d